### PR TITLE
Fix issue with not being able to convert to valid credentials from pr…

### DIFF
--- a/PSLeankit.psm1
+++ b/PSLeankit.psm1
@@ -221,7 +221,7 @@ function Get-LeanKitProfile{
 
     # Convert the credential property into a PSCredentials object if it exists
     if($private:ProfileProperties.credential){
-        $private:Params = @{ArgumentList = @($ProfileValues.credential.username, $(ConvertTo-SecureString $ProfileValues.credential.password))}
+        $private:Params = @{ArgumentList = @($private:ProfileProperties.credential.username, $(ConvertTo-SecureString $private:ProfileProperties.credential.password))}
         $private:ProfileProperties.credential = New-Object System.Management.Automation.PSCredential @private:Params
     }
 


### PR DESCRIPTION
The variable $pivate:ProfileProperties did not contain any values so the ConvertTo-SecureString failed due to a null value.